### PR TITLE
rm unneccessary statements updating/replacing urls

### DIFF
--- a/Controllers/Frontend/ShareBasket.php
+++ b/Controllers/Frontend/ShareBasket.php
@@ -150,7 +150,7 @@ class Shopware_Controllers_Frontend_ShareBasket extends Enlight_Controller_Actio
                 ])
                 ->execute();
 
-            return $this->generateBasketUrl($basketId);
+            return $this->generateBasketUrl($basketId, false);
         }
 
         $statement = $this->container->get('dbal_connection')
@@ -188,16 +188,19 @@ class Shopware_Controllers_Frontend_ShareBasket extends Enlight_Controller_Actio
 
     /**
      * @param $basketId
+     * @param $insert
      *
      * @return string
      */
-    public function generateBasketUrl($basketId)
+    public function generateBasketUrl($basketId, $insert = true)
     {
         $path = 'loadBasket/' . $basketId;
 
-        /** @var \sRewriteTable $rewriteTableModule */
-        $rewriteTableModule = $this->container->get('modules')->sRewriteTable();
-        $rewriteTableModule->sInsertUrl('sViewport=ShareBasket&sAction=load&bID=' . $basketId, $path);
+        if ($insert) {
+            /** @var \sRewriteTable $rewriteTableModule */
+            $rewriteTableModule = $this->container->get('modules')->sRewriteTable();
+            $rewriteTableModule->sInsertUrl('sViewport=ShareBasket&sAction=load&bID=' . $basketId, $path);
+        }
 
         return $path;
     }


### PR DESCRIPTION
when an identical basket is found via hash, we can assume that a rewrite url has already been in inserted, so we can cut unnecessary `UPDATE` and `REPLACE` statements executed by `sInsertUrl`