### PR TITLE
add missing comma

### DIFF
--- a/Resources/views/backend/analytics/frosh_share_basket/store/navigation.js
+++ b/Resources/views/backend/analytics/frosh_share_basket/store/navigation.js
@@ -8,5 +8,5 @@
     comparable: false,
     leaf: true,
     multiShop: true
-}
+},
 // {/block}


### PR DESCRIPTION
This fixes an js error with other plugins try to extend the block 'backend/analytics/store/navigation/items'.