### PR TITLE
Fix attribute fetching if hostname contains `backend`

### DIFF
--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -56,7 +56,7 @@
                 pageSize: 25,
                 proxy: {
                     type: 'ajax',
-                    url: window.location.href.substr(0, window.location.href.indexOf('backend')) + 'backend/AttributeData/list?raw=1&table=s_order_details_attributes',
+                    url: window.location.href.substr(0, window.location.href.lastIndexOf('backend')) + 'backend/AttributeData/list?raw=1&table=s_order_details_attributes',
                     reader: {
                         type: 'json',
                         root: 'data',


### PR DESCRIPTION
#18 

Both protocol and host are supported by all desktop browsers.

https://developer.mozilla.org/en-US/docs/Web/API/Location/protocol
https://developer.mozilla.org/en-US/docs/Web/API/Location/host